### PR TITLE
Multi-arch support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,11 @@ description: |
 
 grade: devel
 confinement: strict
-
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: ppc64el
+  - build-on: s390x
 apps:
   mysqld-exporter:
     command: 'bin/mysqld-exporter-service'


### PR DESCRIPTION
Build the snap for all the architectures mysql-innodb-cluster charm supports:

- amd64
- arm64
- ppc64el
- s390x