### PR TITLE
Fix snap helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
+# Spell checking tools configuration
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"
+
 # Formatting tools configuration
 [tool.black]
 line-length = 99

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # for interacting with snap
-git+https://github.com/albertodonato/snap-helpers#egg=snap-helpers
+snap-helpers < 4.0
 jinja2

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# NOTE(wolsen) Normally these would be written out by the
-# snap-helpers write-hooks command, but it writes out a
-# command-chain snapcraft-runner directive which is not
-# recognized in core22. Need to determine if this is a bug
-# or not in the snap-helpers. In the meantime, we'll just
-# write the file directly.
-exec "${SNAP}/bin/snap-helpers-hook" "configure"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# NOTE(wolsen) Normally these would be written out by the
-# snap-helpers write-hooks command, but it writes out a
-# command-chain snapcraft-runner directive which is not
-# recognized in core22. Need to determine if this is a bug
-# or not in the snap-helpers. In the meantime, we'll just
-# write the file directly.
-exec "${SNAP}/bin/snap-helpers-hook" "install"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,13 @@ parts:
   snap-hooks:
     source: .
     plugin: python
+    build-packages:
+      - git
+    python-requirements:
+      - requirements.txt
+    override-build: |
+      craftctl default
+      snap-helpers write-hooks
 
   templates:
     source: templates/

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,12 +34,12 @@ def snap_env():
         "SNAP_USER_COMMON": "",
         "SNAP_USER_DATA": "",
         "SNAP_VERSION": "1.2.3",
+        "SNAP_REAL_HOME": "/home/foobar",
     }
 
 
 @pytest.fixture
 def snap(snap_env):
-    """"""
     snap = Snap(environ=snap_env)
     snap.config = MagicMock(SnapConfig)
     yield snap

--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,7 @@ deps =
     isort
     codespell
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/venv
+    codespell {toxinidir}
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]src_path}
     isort --check-only --diff {[vars]src_path}


### PR DESCRIPTION
## Issue

Snap hooks from snap-helpers should be generated locally on each build. Failing to do that, the snap hooks were hard coded scripts assuming everything went as planned. Thus, the hooks were installed but dependent snap-helper-hooks scripting did not exist. This appears to be due to changes in the associated snap-helpers library which is used to tie the python bits into the snap hooks.

The snap's requirements.txt file unfortunately referenced the snap-helpers github project directly instead of the one published to pypi, which caused updated changes to cause problems.

Now this being said, the functional tests of previous CI runs *did* indeed catch this issue, as is evidenced by the following bit of output in a previous pull request:

```
Run sudo snap install --dangerous mysqld-exporter_v0.14.0_amd64.snap
error: cannot perform the following tasks:
- Run install hook of "mysqld-exporter" snap if present (run hook "install": /snap/mysqld-exporter/x1/snap/hooks/install: 9: exec: /snap/mysqld-exporter/x1/bin/snap-helpers-hook: not found)
Error: Process completed with exit code 1.
```

However, there were other errors in the unit and linting tests which likely shadowed the functional tests as well. Furthermore, it was not apparent and evident that the building and publishing of the snap happened automatically due to having the repository configured to [build from github](https://snapcraft.io/docs/build-from-github) so that non-amd64 architecture support (ppc64el, s390x, arm64 and riscv) can be included and published.

This caused the installation of the snap to fail as it referenced a script which was no longer valid.

Closes: #4 

## Solution

The way this should work is to let the snap-helpers write-hooks script do the appropriate work here to install the hooks at snap build time. This requires an override to the snap build step that will write the hooks after running the default python build step.

Additionally, there are commits in this PR which address the other causes of the failures - namely the linting and unit test failures in an effort to rely on the in-place CI.